### PR TITLE
Fix types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Probability [![Build Status](https://travis-ci.org/BlackBrane/probability.svg?branch=master)](https://travis-ci.org/BlackBrane/probability)
+# Probability [![Build Status](https://travis-ci.org/fieldstrength/probability.svg?branch=master)](https://travis-ci.org/fieldstrength/probability)
 
 _Probabilistic computation in Idris._
 

--- a/src/Probability/Core.idr
+++ b/src/Probability/Core.idr
@@ -17,7 +17,7 @@ data Probability p a = Pr (List (a,p))
 ---- Types ----
 
 Prob : Type -> Type
-Prob = Probability Float
+Prob = Probability Double
 
 Transition : Type -> Type -> Type
 Transition a b = a -> Prob b
@@ -46,7 +46,7 @@ flat : List a -> Prob a
 flat l = let s = (1 / (cast $ length l))
   in Pr $ (\x => (x,s)) <$> l
 
-shape : List a -> List Float -> Prob a
+shape : List a -> List Double -> Prob a
 shape xs ps = Pr $ zipWith MkPair xs (normalize ps)
 
 

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -7,18 +7,18 @@ import Probability.Utils
 %default total
 
 ||| Sets the width of terminal graph displays
-width : Float
+width : Double
 width = 30
 
 ---- Floating Point Utils ----
 
-castFN : Float -> Nat
+castFN : Double -> Nat
 castFN = cast . cast {to=Integer}
 
-intPart : Float -> Float
+intPart : Double -> Double
 intPart = cast . cast {to=Integer}
 
-fracPart : Float -> Float
+fracPart : Double -> Double
 fracPart x = x - intPart x
 
 ||| Raise a float to an arbitrary integral power
@@ -38,25 +38,25 @@ tipChars = ["▉",
             "▎",
             "▏"]
 
-tipVals : List Float
+tipVals : List Double
 tipVals = (+ 0.0625) . (/8) . cast <$> reverse [1..7]
      -- = [15/16, 13/16, 11/16, 9/16, 7/16, 5/16, 3/16]
 
 
-tips : List (Float,String)
+tips : List (Double,String)
 tips = zipWith MkPair tipVals tipChars
 
-selectTip : Float -> String
+selectTip : Double -> String
 selectTip x = let l = filter (\p => fst p < x) tips
   in case l of
      [] => ""
      ((f,s)::ss) => s
 
 
-bar : Float -> String
+bar : Double -> String
 bar f = pack (replicate (castFN f) '█') ++ selectTip (fracPart f)
 
-bars : List Float -> List String
+bars : List Double -> List String
 bars l = let mx = foldr max 0 l
   in map bar $ map (* width/mx) l
 
@@ -82,26 +82,26 @@ digit 7 = '7'
 digit 8 = '8'
 digit 9 = '9'
 
-digAt : Float -> Integer -> Integer
+digAt : Double -> Integer -> Integer
 digAt x i = flip mod 10 $ cast $ abs $ x / (fpow 10 i)
 
-charAt : Float -> Integer -> Char
+charAt : Double -> Integer -> Char
 charAt x i = digit $ digAt x i
 
 
-scanUp : Float -> Integer -> Integer
+scanUp : Double -> Integer -> Integer
 scanUp x n = if x < (fpow 10 $ n + 1) then n else scanUp x (n + 1)
 
-scanDown : Float -> Integer -> Integer
+scanDown : Double -> Integer -> Integer
 scanDown x n = if x > (fpow 10 $ -n) then -n else scanDown x (n + 1)
 
-||| Find the leading digit of a Float
-maxdig : Float -> Integer
+||| Find the leading digit of a Double
+maxdig : Double -> Integer
 maxdig x = if x > 1 then scanUp x 0
                     else scanDown x 1
 
 ||| Show 4 digits (not necessarily significant) of a percentage
-showPercent : Float -> String
+showPercent : Double -> String
 showPercent x = let y  = 100 * x
                     s1 = pack $ (charAt y) <$> [1,0]
                     s2 = pack $ (charAt y) <$> [-1,-2]

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -21,10 +21,10 @@ intPart = cast . cast {to=Integer}
 fracPart : Double -> Double
 fracPart x = x - intPart x
 
-||| Raise a float to an arbitrary integral power
-fpow : Float -> Integer -> Float
 fpow f p = if p >= 0 then pow f (cast p)
                      else 1 / (pow f $ cast $ abs p)
+||| Raise a double to an arbitrary integral power
+fpow : Double -> Integer -> Double
 
 
 ---- Display Bars ----

--- a/src/Probability/Utils.idr
+++ b/src/Probability/Utils.idr
@@ -19,7 +19,7 @@ vecEq []      []      = True
 vecEq _       _       = False
 
 
-normalize : List Float -> List Float
+normalize : List Double -> List Double
 normalize l = (/ (sum l)) <$> l
 
 left : (a -> c) -> (a,b) -> (c,b)


### PR DESCRIPTION
The only change in this PR is updating the old name for the primitive floating-point number datatype `Float` to the new one `Double`. For more information, see [the relevant issue at the Idris repo here](https://github.com/idris-lang/Idris-dev/issues/379).
