### PR TITLE
Update to be compatible with Idris 1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 
 install:
-  - cabal install idris
+  - travis_wait cabal install idris
 
 script:
   - idris --install probability.ipkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 
 install:
-  - travis_wait cabal install idris
+  - travis_wait 60 cabal install idris
 
 script:
   - idris --install probability.ipkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
   - travis_wait 60 cabal install idris
 
 script:
-  - idris --install probability.ipkg
+  - ~/.cabal/bin/idris --install probability.ipkg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Probability [![Build Status](https://travis-ci.org/BlackBrane/probability.svg?branch=master)](https://travis-ci.org/BlackBrane/probability)
+# Probability [![Build Status](https://travis-ci.org/fieldstrength/probability.svg?branch=master)](https://travis-ci.org/fieldstrength/probability)
 
 _Probabilistic computation in Idris._
 

--- a/src/Probability/Core.idr
+++ b/src/Probability/Core.idr
@@ -5,23 +5,24 @@ import Probability.Utils
 
 %default total
 
+%access export
+
 
 ||| Representation of a probability distribution
-abstract
 data Probability p a = Pr (List (a,p))
-
-
-%access public
 
 
 ---- Types ----
 
+public export
 Prob : Type -> Type
 Prob = Probability Double
 
+public export
 Transition : Type -> Type -> Type
 Transition a b = a -> Prob b
 
+public export
 Trans : Type -> Type
 Trans t = Transition t t
 
@@ -52,14 +53,14 @@ shape xs ps = Pr $ zipWith MkPair xs (normalize ps)
 
 ---- Instances ----
 
-instance Functor (Probability p) where
+Functor (Probability p) where
   map f (Pr l) = Pr $ left f <$> l
 
-instance Num p => Applicative (Probability p) where
+Num p => Applicative (Probability p) where
   pure     = certainly
   fm <*> m = Pr [ (f x, q*w) | (f,w) <- runProb fm, (x,q) <- runProb m ]
 
-instance Num p => Monad (Probability p) where
+Num p => Monad (Probability p) where
   d >>= f = Pr [ (y, q*w) | (x,w) <- runProb d, (y,q) <- runProb (f x) ]
 
 

--- a/src/Probability/Core.idr
+++ b/src/Probability/Core.idr
@@ -17,7 +17,7 @@ data Probability p a = Pr (List (a,p))
 ---- Types ----
 
 Prob : Type -> Type
-Prob = Probability Float
+Prob = Probability Double
 
 Transition : Type -> Type -> Type
 Transition a b = a -> Prob b
@@ -46,7 +46,7 @@ flat : List a -> Prob a
 flat l = let s = (1 / (cast $ length l))
   in Pr $ (\x => (x,s)) <$> l
 
-shape : List a -> List Float -> Prob a
+shape : List a -> List Double -> Prob a
 shape xs ps = Pr $ zipWith MkPair xs (normalize ps)
 
 

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -7,18 +7,18 @@ import Probability.Utils
 %default total
 
 ||| Sets the width of terminal graph displays
-width : Float
+width : Double
 width = 30
 
 ---- Floating Point Utils ----
 
-castFN : Float -> Nat
+castFN : Double -> Nat
 castFN = cast . cast {to=Integer}
 
-intPart : Float -> Float
+intPart : Double -> Double
 intPart = cast . cast {to=Integer}
 
-fracPart : Float -> Float
+fracPart : Double -> Double
 fracPart x = x - intPart x
 
 ||| Raise a float to an arbitrary integral power
@@ -38,25 +38,25 @@ tipChars = ["▉",
             "▎",
             "▏"]
 
-tipVals : List Float
+tipVals : List Double
 tipVals = (+ 0.0625) . (/8) . cast <$> reverse [1..7]
      -- = [15/16, 13/16, 11/16, 9/16, 7/16, 5/16, 3/16]
 
 
-tips : List (Float,String)
+tips : List (Double,String)
 tips = zipWith MkPair tipVals tipChars
 
-selectTip : Float -> String
+selectTip : Double -> String
 selectTip x = let l = filter (\p => fst p < x) tips
   in case l of
      [] => ""
      ((f,s)::ss) => s
 
 
-bar : Float -> String
+bar : Double -> String
 bar f = pack (replicate (castFN f) '█') ++ selectTip (fracPart f)
 
-bars : List Float -> List String
+bars : List Double -> List String
 bars l = let mx = foldr max 0 l
   in map bar $ map (* width/mx) l
 
@@ -82,26 +82,26 @@ digit 7 = '7'
 digit 8 = '8'
 digit 9 = '9'
 
-digAt : Float -> Integer -> Integer
+digAt : Double -> Integer -> Integer
 digAt x i = flip mod 10 $ cast $ abs $ x / (fpow 10 i)
 
-charAt : Float -> Integer -> Char
+charAt : Double -> Integer -> Char
 charAt x i = digit $ digAt x i
 
 
-scanUp : Float -> Integer -> Integer
+scanUp : Double -> Integer -> Integer
 scanUp x n = if x < (fpow 10 $ n + 1) then n else scanUp x (n + 1)
 
-scanDown : Float -> Integer -> Integer
+scanDown : Double -> Integer -> Integer
 scanDown x n = if x > (fpow 10 $ -n) then -n else scanDown x (n + 1)
 
-||| Find the leading digit of a Float
-maxdig : Float -> Integer
+||| Find the leading digit of a Double
+maxdig : Double -> Integer
 maxdig x = if x > 1 then scanUp x 0
                     else scanDown x 1
 
 ||| Show 4 digits (not necessarily significant) of a percentage
-showPercent : Float -> String
+showPercent : Double -> String
 showPercent x = let y  = 100 * x
                     s1 = pack $ (charAt y) <$> [1,0]
                     s2 = pack $ (charAt y) <$> [-1,-2]

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -21,10 +21,10 @@ intPart = cast . cast {to=Integer}
 fracPart : Double -> Double
 fracPart x = x - intPart x
 
-fpow f p = if p >= 0 then pow f (cast p)
-                     else 1 / (pow f $ cast $ abs p)
 ||| Raise a double to an arbitrary integral power
 fpow : Double -> Integer -> Double
+fpow f p = if p >= 0 then pow f (cast p)
+                     else 1 / (pow f $ cast $ abs p)
 
 
 ---- Display Bars ----

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -21,10 +21,10 @@ intPart = cast . cast {to=Integer}
 fracPart : Double -> Double
 fracPart x = x - intPart x
 
-||| Raise a float to an arbitrary integral power
-fpow : Float -> Integer -> Float
 fpow f p = if p >= 0 then pow f (cast p)
                      else 1 / (pow f $ cast $ abs p)
+||| Raise a double to an arbitrary integral power
+fpow : Double -> Integer -> Double
 
 
 ---- Display Bars ----

--- a/src/Probability/Display.idr
+++ b/src/Probability/Display.idr
@@ -23,8 +23,8 @@ fracPart x = x - intPart x
 
 ||| Raise a double to an arbitrary integral power
 fpow : Double -> Integer -> Double
-fpow f p = if p >= 0 then pow f (cast p)
-                     else 1 / (pow f $ cast $ abs p)
+fpow f p = if p >= 0 then Prelude.pow f (cast p)
+                     else 1 / (Prelude.pow f $ cast $ abs p)
 
 
 ---- Display Bars ----

--- a/src/Probability/Examples/MontyHall.idr
+++ b/src/Probability/Examples/MontyHall.idr
@@ -11,13 +11,13 @@ import Data.Vect
 
 data Door = One | Two | Three
 
-instance Eq Door where
+Eq Door where
   One   == One   = True
   Two   == Two   = True
   Three == Three = True
   _     == _     = False
 
-instance Show Door where
+Show Door where
   show One   = "Door #1"
   show Two   = "Door #2"
   show Three = "Door #3"
@@ -47,10 +47,10 @@ score {k} v = case k of
 
 data GameScore = Score (Vect (S (S n)) Door)
 
-instance Eq GameScore where
+Eq GameScore where
   (Score v) == (Score w) = vecEq v w
 
-instance Show GameScore where
+Show GameScore where
   show (Score v) = let status = if score v then " WIN  " else " LOSE "
     in  status ++ show v
 
@@ -58,10 +58,10 @@ instance Show GameScore where
 
 data GameOutcome = Outcome (Monty (S (S n)))
 
-instance Eq GameOutcome where
+Eq GameOutcome where
   (Outcome v) == (Outcome w) = score v == score w
 
-instance Show GameOutcome where
+Show GameOutcome where
   show (Outcome v) = if score v then " WIN  " else " LOSE "
 
 

--- a/src/Probability/Monad.idr
+++ b/src/Probability/Monad.idr
@@ -3,6 +3,7 @@ module Probability.Monad
 
 %default total
 
+%access export
 
 infixr 6 >=>
 (>=>) : Monad m => (a -> m b) -> (b -> m c) -> a -> m c

--- a/src/Probability/Monad.idr
+++ b/src/Probability/Monad.idr
@@ -15,7 +15,7 @@ infixl 6 <=<
 
 
 sequ : Monad m => List (a -> m a) -> a -> m a
-sequ = foldl (>=>) return
+sequ = foldl (>=>) pure
 
 
 perform : Monad m => Nat -> (a -> m a) -> a -> m a

--- a/src/Probability/Utils.idr
+++ b/src/Probability/Utils.idr
@@ -19,7 +19,7 @@ vecEq []      []      = True
 vecEq _       _       = False
 
 
-normalize : List Float -> List Float
+normalize : List Double -> List Double
 normalize l = (/ (sum l)) <$> l
 
 left : (a -> c) -> (a,b) -> (c,b)

--- a/src/Probability/Utils.idr
+++ b/src/Probability/Utils.idr
@@ -5,6 +5,7 @@ import Data.Vect
 
 %default total
 
+%access export
 
 infixl 5 ::~
 


### PR DESCRIPTION
This PR should update the library to be compatible with Idris 1.3.1. The [error pointed out](https://github.com/fieldstrength/probability/pull/1#issuecomment-372909195) by @ivanperez-keera is also addressed here. Tested and seems to be working great. Does bring the changes across from PR #1 so major props to @clayrat.